### PR TITLE
fixed typo in package.json/repository/url

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "Craig Condon",
     "repository": {
         "type": "git",
-        "url": "http://github.com/spiceapps/celery.git"
+        "url": "http://github.com/spiceapps/celeri.git"
     },
     "directories" :   { "lib" : "./lib" },
     "dependencies": {


### PR DESCRIPTION
celery should be celeri :)
