### PR TITLE
added a if for the case when defaults don't exist

### DIFF
--- a/lib/plugins/help.js
+++ b/lib/plugins/help.js
@@ -125,19 +125,21 @@ exports.plugin = function(cli) {
 
         var k;
 
-        for(var op in ops.optional) {
+        if(ops.defaults) { 
+            for(var op in ops.optional) {
 
-            k = op;
+                k = op;
 
-            if(ops.defaults[op]) {
-                k = k + "=" + ops.defaults[k];
+                if(ops.defaults[op]) {
+                    k = k + "=" + ops.defaults[k];
+                }
+
+                
+                childHelp.add('Optional Flags', "--" + k, ops.optional[op]);
+                
             }
-
-            
-            childHelp.add('Optional Flags', "--" + k, ops.optional[op]);
-            
         }
-        
+
         return cli;
     }
 


### PR DESCRIPTION
I was trying to run the example given on the README and got always a error because of the optional arguments:

```
/Users/david/Code/nsp/node_modules/celeri/lib/plugins/help.js:135
            if(ops.defaults[op]) {
                           ^
TypeError: Cannot read property '--age' of undefined
```

So I confined the for loop in a if statement to make sure that doesn't get executed if .defaults doesn't exist, so far is working right. I'm not sure thought if 'defaults' was actually a typo and should it by optional (because that makes it work too)
