### PR TITLE
print help if no arguments are passed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -248,8 +248,11 @@ exports.parse = function(args, callback) {
     var cmd = { command: command, data: data };
 
     exports.next(function() {
+        if(command.length === 0 ){
+            self.emit('help');
+            return;
+        }
         
-
         if(!self.emit(command, data)) {
             if(command.join('').length) {
                 var err = new Error('command "'+command.join(' ')+'" does not exist')


### PR DESCRIPTION
This way, if the module name is typed without any args, the help menu is printed
